### PR TITLE
feat: 支持 sitemap 接口

### DIFF
--- a/api/router/router.go
+++ b/api/router/router.go
@@ -18,6 +18,8 @@ func Group(r *gin.Engine) {
 	})
 
 	r.GET("/statistics", api.GetStatistics)
+	r.GET("/sitemap/ranklist.xml", api.SitemapRanklistIndex)
+	r.GET("/sitemap/ranklist_vol_:volName", api.SitemapRanklistVol)
 
 	rank(r.Group("/rank"))
 	ranking(r.Group("/ranking"))

--- a/logic/sitemap.go
+++ b/logic/sitemap.go
@@ -1,0 +1,31 @@
+package logic
+
+import (
+	"rankland/model/rank"
+)
+
+const (
+	SitemapVolCap = 1000
+)
+
+func GetRankSitemapVolCount() (volCnt int32, err error) {
+	rankCnt, err := rank.GetRankCntStatistics()
+	if err != nil {
+		return 0, err
+	}
+
+	return (rankCnt + SitemapVolCap - 1) / SitemapVolCap, nil
+}
+
+func GetRankSitemapVol(volIdx int) (uniqueKeys []string, err error) {
+	if volIdx < 1 {
+		return []string{}, nil
+	}
+	offset := (volIdx - 1) * SitemapVolCap
+	uniqueKeys, err = rank.GetAllRankUniqueKeys(offset, SitemapVolCap)
+	if err != nil {
+		return []string{}, err
+	}
+
+	return uniqueKeys, nil
+}

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	r.Use(
 		middleware.Cors(app.Cors), // 启用跨域拦截
 		middleware.Error(),        // 启用 Error 处理
+		middleware.XMLHeader(),    // 启用 XML Header
 	)
 
 	router.Group(r)

--- a/middleware/xml.go
+++ b/middleware/xml.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// XMLHeader
+func XMLHeader() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		if strings.HasSuffix(ctx.Request.URL.Path, ".xml") && ctx.NegotiateFormat(gin.MIMEXML) == gin.MIMEXML {
+			ctx.Writer.Write([]byte(xml.Header))
+		}
+
+		ctx.Next()
+	}
+}

--- a/model/rank/action.go
+++ b/model/rank/action.go
@@ -90,6 +90,41 @@ func GetRankStatistics() (rankCnt, ViewCnt int32, err error) {
 	return rs.RankCnt, rs.ViewCnt, nil
 }
 
+type RankCntStatistics struct {
+	RankCnt int32
+}
+
+func GetRankCntStatistics() (rankCnt int32, err error) {
+	rs := RankCntStatistics{}
+	db := load.GetDB().Model(&Rank{})
+	sql := db.Select("count(*) as rank_cnt").Find(&rs)
+	if sql.Error != nil {
+		return 0, sql.Error
+	}
+
+	return rs.RankCnt, nil
+}
+
+type RankOnlyUniqueKey struct {
+	UniqueKey string
+}
+
+func GetAllRankUniqueKeys(offset int, limit int) (uniqueKey []string, err error) {
+	rs := []RankOnlyUniqueKey{}
+	db := load.GetDB().Model(&Rank{})
+	sql := db.Distinct("unique_key").Offset(offset).Limit(limit).Find(&rs)
+	if sql.Error != nil {
+		return []string{}, sql.Error
+	}
+
+	uniqueKeys := make([]string, 0, len(rs))
+	for _, r := range rs {
+		uniqueKeys = append(uniqueKeys, r.UniqueKey)
+	}
+
+	return uniqueKeys, nil
+}
+
 func GetRankGroupByID(id int64) (*RankGroup, error) {
 	rg := &RankGroup{}
 	db := load.GetDB().Where("id = ?", id)

--- a/model/rank/action.go
+++ b/model/rank/action.go
@@ -97,7 +97,7 @@ type RankCntStatistics struct {
 func GetRankCntStatistics() (rankCnt int32, err error) {
 	rs := RankCntStatistics{}
 	db := load.GetDB().Model(&Rank{})
-	sql := db.Select("count(*) as rank_cnt").Find(&rs)
+	sql := db.Select("count(distinct unique_key) as rank_cnt").Find(&rs)
 	if sql.Error != nil {
 		return 0, sql.Error
 	}


### PR DESCRIPTION
sitemap.xml 接口，分卷输出，url 为 `/sitemap/ranklist.xml`：
```xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <sitemap><loc>https://rl.algoux.org/sitemap/ranklist_vol_1.txt</loc></sitemap>
  <sitemap><loc>https://rl.algoux.org/sitemap/ranklist_vol_2.txt</loc></sitemap>
</sitemapindex>
```

sitemap vol txt 接口，每个分卷内不超过 1000 个网址，url 为 `/sitemap/ranklist_vol_${index}.txt`：
```plain
https://rl.algoux.org/ranklist/uniqueKey1
https://rl.algoux.org/ranklist/uniqueKey2
```